### PR TITLE
[EBS-38] Remove window capture

### DIFF
--- a/vendor_skins/Evercast/UI/window-basic-main.cpp
+++ b/vendor_skins/Evercast/UI/window-basic-main.cpp
@@ -4598,7 +4598,12 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 		popup->insertAction(after, popupItem);
 	};
 
+	bool showAdvancedOptions = config_get_bool(this->Config(), "General", "ShowAdvancedOptions");
 	while (obs_enum_input_types(idx++, &type)) {
+		if (strncmp(type, "window_capture", strlen(type)) == 0 && !showAdvancedOptions) {
+			continue;
+		}
+
 		const char *name = obs_source_get_display_name(type);
 		uint32_t caps = obs_get_source_output_flags(type);
 


### PR DESCRIPTION
Window capture no longer displays as a source option by default.  If "show advanced options" is selected in configuration, it will be present.