### PR TITLE
feature: [EBS-43] TURN support and fallback for servers which don't include ICE servers in join response

### DIFF
--- a/plugins/websocket-client/CMakeLists.txt
+++ b/plugins/websocket-client/CMakeLists.txt
@@ -52,6 +52,7 @@ set(websocketclient_SOURCES
 	WowzaWebsocketClientImpl.cpp
 	MillicastWebsocketClientImpl.cpp
 	EvercastWebsocketClientImpl.cpp
+	EvercastSessionData.cpp
 	VideoRoomWebsocketClientImpl.cpp
 	restclient-cpp/source/connection.cc
 	restclient-cpp/source/helpers.cc
@@ -68,6 +69,7 @@ set(websocketclient_HEADERS
 	WowzaWebsocketClientImpl.h
 	MillicastWebsocketClientImpl.h
 	EvercastWebsocketClientImpl.h
+	EvercastSessionData.h
 	VideoRoomWebsocketClientImpl.h)
 
 add_library(websocketclient SHARED

--- a/plugins/websocket-client/EvercastSessionData.cpp
+++ b/plugins/websocket-client/EvercastSessionData.cpp
@@ -1,0 +1,68 @@
+#include "EvercastSessionData.h"
+
+std::map<long long, EvercastSessionData*> EvercastSessionData::sessions = {};
+
+EvercastSessionData* EvercastSessionData::findOrCreateSession(long long key)
+{
+    EvercastSessionData *result = sessions[key];
+    if (NULL == result) {
+        result = new EvercastSessionData(key);
+        sessions[key] = result;
+    }
+
+    return result;
+}
+
+bool EvercastSessionData::terminateSession(long long key)
+{
+    EvercastSessionData *data = sessions[key];
+    if (NULL == data) {
+        return false;
+    }
+
+    sessions.erase(key);
+    delete data;
+
+    return true;
+}
+
+void EvercastSessionData::storeIceServers(std::vector<IceServerDefinition> &servers)
+{
+    // Actually modify ice servers
+    {
+        const std::lock_guard<std::mutex> lock(initialization_mutex);
+        this->ice_servers = std::vector<IceServerDefinition>(servers);
+    }
+
+    initialized_condition.notify_all();
+}
+
+std::vector<IceServerDefinition> EvercastSessionData::awaitIceServers()
+{
+    std::unique_lock<std::mutex> server_lock(initialization_mutex);
+
+    while(!closing && ice_servers.empty()) {
+        initialized_condition.wait(server_lock);
+    }
+
+    server_lock.unlock();
+
+    return ice_servers;
+}
+
+EvercastSessionData::EvercastSessionData(long long key)
+{
+    this->session_key = key;
+    this->closing = false;
+}
+
+EvercastSessionData::~EvercastSessionData()
+{
+    closing = true;
+
+    // Release init condition so that anyone who is waiting can wrap up and let go
+    initialized_condition.notify_all();
+
+    // Remove self from static connection collection
+    terminateSession(this->session_key);
+}

--- a/plugins/websocket-client/EvercastSessionData.h
+++ b/plugins/websocket-client/EvercastSessionData.h
@@ -1,0 +1,48 @@
+#ifndef __EVERCAST_SESSION_DATA_H__
+#define __EVERCAST_SESSION_DATA_H__
+
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <vector>
+#include <map>
+
+struct IceServerDefinition {
+	std::string urls;
+	std::string username;
+	std::string password;
+};
+
+/**
+ * Manages Evercast session state.  Currently only used to hold ICE servers and
+ * provide access to them from outside; other state will follow.  Lifetime of
+ * instances of this type will match the lifetime of Evercast WebSockets.
+ */
+class EvercastSessionData {
+public:
+    // Create a new session instance, or find one with the appropriate key.
+	static EvercastSessionData *findOrCreateSession(long long key);
+    // Destroy the specified session instance.
+	static bool terminateSession(long long key);
+
+    // Wait for ICE servers to be provided by the client.
+	std::vector<IceServerDefinition> awaitIceServers();
+
+    // Write a list of ICE servers to the session for use by its owner
+    void storeIceServers(std::vector<IceServerDefinition> &servers);
+
+private:
+	static std::map<long long, EvercastSessionData*> sessions;
+
+    long long session_key;
+    bool closing;
+
+	std::mutex initialization_mutex;
+	std::condition_variable initialized_condition;
+	std::vector<IceServerDefinition> ice_servers;
+
+	EvercastSessionData(long long key);
+	~EvercastSessionData();
+};
+
+#endif

--- a/plugins/websocket-client/EvercastSessionData.h
+++ b/plugins/websocket-client/EvercastSessionData.h
@@ -34,8 +34,8 @@ public:
 private:
 	static std::map<long long, EvercastSessionData*> sessions;
 
-    long long session_key;
-    bool closing;
+	long long session_key;
+	bool closing;
 
 	std::mutex initialization_mutex;
 	std::condition_variable initialized_condition;

--- a/plugins/websocket-client/EvercastWebsocketClientImpl.h
+++ b/plugins/websocket-client/EvercastWebsocketClientImpl.h
@@ -2,6 +2,7 @@
 #define __EVERCAST_WEBSOCKET_CLIENT_IMPL_H__
 
 #include "WebsocketClient.h"
+#include "EvercastSessionData.h"
 
 //Use http://think-async.com/ instead of boost
 #define ASIO_STANDALONE
@@ -77,6 +78,8 @@ protected:
                           WebsocketClient::Listener * listener);
     int parsePluginErrorCode(nlohmann::json &msg);
     bool hasTimedOut();
+    bool processJoinResponse(nlohmann::json &msg);
+    void defineIceServers(std::vector<IceServerDefinition> &ice_servers);
 };
 
 #endif // __EVERCAST_WEBSOCKET_CLIENT_IMPL_H__

--- a/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.h
+++ b/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.h
@@ -15,6 +15,7 @@
 #include "VideoCapturer.h"
 #include "AudioDeviceModuleWrapper.h"
 #include "EvercastAudioSource.h"
+#include "EvercastSessionData.h"
 
 #include "api/create_peerconnection_factory.h"
 #include "api/media_stream_interface.h"
@@ -177,6 +178,12 @@ private:
 
   // OBS stream output
   obs_output_t *output;
+
+  webrtc::PeerConnectionInterface::IceServers ice_servers;
+
+  bool startWebSocket(WebRTCStream::Type type);
+  bool startPeerConnection();
+  void createOffer();
 };
 
 #endif


### PR DESCRIPTION
- EBS will now check for a list of ICE servers when it receives the response to its join request.
- If no servers are specified, it will fall back to the default (previous) stun server
- Init process has been refactored to ensure join action is carried out (and ICE servers returned) before the peerconnection is created.
- EvercastSessionData object coordinates receipt of session metadata from Janus server with the EBS stream responsible for sending data to it.  The plan is to extend this to better handle empty rooms, error-related socket shutdown, etc.