### PR TITLE
bug: Display capture fails on some Windows systems

### DIFF
--- a/vendor_skins/Evercast/CI/install/win/Install EBS.wxs
+++ b/vendor_skins/Evercast/CI/install/win/Install EBS.wxs
@@ -3,7 +3,7 @@
 	xmlns:bal="http://schemas.microsoft.com/wix/BalExtension"
 	xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 	<Bundle
-	      Version="2.5.3"
+	      Version="2.5.5"
 	      UpgradeCode="01234567-89AB-CDEF-0123-456789ABCDEF"
 	      Manufacturer="Evercast"
 	      IconSourceFile=".\ebs.ico"
@@ -41,7 +41,7 @@
 				InstallCommand="/q /ACTION=Install"
 				RepairCommand="/q ACTION=Repair /hideconsole"
 				Permanent="yes" />
-			<MsiPackage SourceFile=".\ebs-x64-2.5.3.msi" />
+			<MsiPackage SourceFile=".\ebs-x64-2.5.5.msi" />
 		</Chain>
 	</Bundle>
 </Wix>

--- a/vendor_skins/Evercast/libobs-d3d11/d3d11-subsystem.hpp
+++ b/vendor_skins/Evercast/libobs-d3d11/d3d11-subsystem.hpp
@@ -956,6 +956,7 @@ struct gs_device {
 	void InitCompiler();
 	void InitFactory(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);
+	int CheckDuplicationSupport();
 
 	ID3D11DepthStencilState *AddZStencilState();
 	ID3D11RasterizerState *AddRasterState();


### PR DESCRIPTION
Ensure that D3D is actually able to capture a display before enabling it vs. the OpenGL fallback option