### PR TITLE
Fixed bitrate selection in SDP for multichannel opus

### DIFF
--- a/plugins/obs-outputs/SDPModif.h
+++ b/plugins/obs-outputs/SDPModif.h
@@ -22,7 +22,7 @@ public:
         // audio section contains at least 1 stereo codec
         if (testLine >= audio_start && testLine <= audio_end)
             return;
-        std::string opusRe = "a=rtpmap:([0-9]{1,3}) [oO][pP][uU][sS]";
+        std::string opusRe = "a=rtpmap:([0-9]{1,3}) ([Mm][Uu][Ll][Tt][Ii])*[oO][pP][uU][sS]";
         int rtpmap = findLinesRegEx(sdpLines, opusRe);
         if (rtpmap == -1)
             return;

--- a/vendor_skins/Evercast/UI/window-basic-main.cpp
+++ b/vendor_skins/Evercast/UI/window-basic-main.cpp
@@ -1191,7 +1191,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_string(basicConfig, "SimpleOutput", "RecFormat",
 				  "mkv");
 	config_set_default_uint(basicConfig, "SimpleOutput", "VBitrate", 2500);
-	config_set_default_uint(basicConfig, "SimpleOutput", "ABitrate", 128);
+	config_set_default_uint(basicConfig, "SimpleOutput", "ABitrate", 320);
 	config_set_default_bool(basicConfig, "SimpleOutput", "UseAdvanced",
 				false);
 	config_set_default_bool(basicConfig, "SimpleOutput", "EnforceBitrate",


### PR DESCRIPTION
Sound engineers noticed that 320kbps sound did not sound right; confirmed that regression for multi-channel sound blocked SDP from defining proper bitrate.  Resolution is in munging the SDP properly.

Confirmed that a much higher bitrate is now available.  Note for debugging that EBS uses 16 bits per sample, and opus max sample rate is 48khz: audio at 32bps and/or 96khz will still be downsampled and bitrate will be lower than might otherwise be expected.

https://evercast.atlassian.net/browse/EBS-63