### PR TITLE
[EBS-84] Resolved display capture problems on Windows

### DIFF
--- a/vendor_skins/Evercast/CI/install/win/Install EBS.wxs
+++ b/vendor_skins/Evercast/CI/install/win/Install EBS.wxs
@@ -3,7 +3,7 @@
 	xmlns:bal="http://schemas.microsoft.com/wix/BalExtension"
 	xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 	<Bundle
-	      Version="2.5.7"
+	      Version="2.5.9"
 	      UpgradeCode="01234567-89AB-CDEF-0123-456789ABCDEF"
 	      Manufacturer="Evercast"
 	      IconSourceFile=".\ebs.ico"
@@ -41,7 +41,7 @@
 				InstallCommand="/q /ACTION=Install"
 				RepairCommand="/q ACTION=Repair /hideconsole"
 				Permanent="yes" />
-			<MsiPackage SourceFile=".\ebs-x64-2.5.7.msi" />
+			<MsiPackage SourceFile=".\ebs-x64-2.5.9.msi" />
 		</Chain>
 	</Bundle>
 </Wix>

--- a/vendor_skins/Evercast/UI/window-basic-main.cpp
+++ b/vendor_skins/Evercast/UI/window-basic-main.cpp
@@ -3534,6 +3534,13 @@ int OBSBasic::ResetVideo()
 		config_get_string(basicConfig, "Video", "ColorRange");
 
 	ovi.graphics_module = App()->GetRenderModule();
+	// OBS 25 introduced some problematic changes to DirectX handling which tend to
+	// break display capture on a lot of Windows machines, so until they get that
+	// figured out we'll run OpenGL.
+	if (ovi.graphics_module == DL_D3D11)
+	{
+		ovi.graphics_module = DL_OPENGL;
+	}
 	ovi.base_width =
 		(uint32_t)config_get_uint(basicConfig, "Video", "BaseCX");
 	ovi.base_height =

--- a/vendor_skins/Evercast/UI/window-basic-settings.cpp
+++ b/vendor_skins/Evercast/UI/window-basic-settings.cpp
@@ -1334,7 +1334,7 @@ void OBSBasicSettings::LoadRendererList()
 	const char *renderer =
 		config_get_string(GetGlobalConfig(), "Video", "Renderer");
 
-	ui->renderer->addItem(QT_UTF8("Direct3D 11"));
+	// ui->renderer->addItem(QT_UTF8("Direct3D 11"));
 	if (opt_allow_opengl || strcmp(renderer, "OpenGL") == 0)
 		ui->renderer->addItem(QT_UTF8("OpenGL"));
 


### PR DESCRIPTION
Recent versions of OBS have introduced issues for some graphics cards when attempting to use display capture.  While it may be possible to troubleshoot these problems individually, it is expedient to fall back to openGL, which appears to have a more stable implementation.

Verifying this fix is difficult, as the capture errors seem to fall into at least three separate categories, and are only reproducible on specific hardware.  For testing, I suggest a "sanity check" - opening EBS, adding a display capture source, and streaming it to Evercast.  This will confirm that display capture has at least not broken as a result of the fix.

Build is available here: https://drive.google.com/file/d/1YfUiZHSAaQsY4uk9-TgiVUsZk4bQr_1K/view?usp=sharing