### PR TITLE
[EBS-88] VLC source

### DIFF
--- a/vendor_skins/Evercast/CI/configure-script-win.cmd
+++ b/vendor_skins/Evercast/CI/configure-script-win.cmd
@@ -19,4 +19,5 @@ cmake ^
   -DFFMPEG_AVCODEC_LIBRARIES=%ffmpegPath%\lib ^
   -DDepsPath64=%DepsPath64% ^
   -DNDI_PATH=%NDIPath% ^
+  -DVLCPath=%VLCPath% ^
   ..


### PR DESCRIPTION
The VLC source appears never to have been included in Windows builds until now.  This is now rectified.

Test build (Windows only; Mac already has VLC source):
https://drive.google.com/file/d/14EcFCNw5oKa8Ket4ljMIwETDBeqYk6VY/view?usp=sharing