### PR TITLE
Resolved error handling issues in mac client

### DIFF
--- a/plugins/websocket-client/EvercastMessageProcessor.cpp
+++ b/plugins/websocket-client/EvercastMessageProcessor.cpp
@@ -92,7 +92,7 @@ void EvercastMessageProcessor::processErrorEvent(int errorCode, json& msg)
 	switch (errorCode) {
 	case EVERCAST_ERR_DUPLICATE_USER:
 		// Launch logged event: someone else is logged in
-		listener->onLogged(session_id);
+		listener->onLoggedError(-EVERCAST_ERR_DUPLICATE_USER);
 		break;
 	case EVERCAST_ERR_UNSUPPORTED_AUDIO_CODEC:
 		blog(LOG_ERROR, "Janus room does not support the audio codec specified.");

--- a/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.cpp
+++ b/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.cpp
@@ -75,6 +75,7 @@ WebRTCStream::WebRTCStream(obs_output_t *output)
     // Store output
     this->output = output;
     this->client = nullptr;
+    this->connection_invalidated = false;
 
     // Create audio device module
     adm = new rtc::RefCountedObject<AudioDeviceModuleWrapper>();
@@ -270,6 +271,7 @@ bool WebRTCStream::startWebSocket(WebRTCStream::Type type)
 	info("CONNECTING TO %s", url.c_str());
 
 	// Connect to server
+    this->connection_invalidated = false;
 	if (!client->connect(url, room, username, password, this)) {
 		recordConnectionError("There was a problem connecting to your Evercast room.  Have you double-checked your room settings?");
 		return false;
@@ -286,7 +288,9 @@ bool WebRTCStream::startWebSocket(WebRTCStream::Type type)
 
 		bool successfullyJoined = session_data->awaitJoinComplete(5);
 		if (!successfullyJoined) {
-			recordConnectionError("There was a problem connecting to your Evercast room.  Are attendees present?");
+            if (!this->connection_invalidated) {
+                recordConnectionError("There was a problem connecting to your Evercast room.  Are attendees present?");
+            }
 			return false;
 		}
 
@@ -603,19 +607,23 @@ void WebRTCStream::onDisconnected()
 void WebRTCStream::onLoggedError(int code)
 {
     info("WebRTCStream::onLoggedError [code: %d]", code);
-    // Shutdown websocket connection and close Peer Connection
-    close(false);
+    this->connection_invalidated = true;
 
+    // Close Peer Connection
     const char *error;
     switch (code)
     {
     case -EVERCAST_ERR_UNSUPPORTED_AUDIO_CODEC:
-	error = "Your Evercast room does not support surround sound.  Try setting output to stereo, then reconnect.";
+        error = "Your Evercast room does not support surround sound.  Try setting output to stereo, then reconnect.";
+        break;
+    case -EVERCAST_ERR_DUPLICATE_USER:
+        error = "Another instance of EBS with the same user account is already broadcasting to this room.";
         break;
     default:
         error = "Evercast is having trouble connecting to your room.  Are you behind a firewall?\n\n"
         "Visit Evercast's <a href=\"https://support.evercast.us/security-whitelisting\">security whitelisting page</a> for firewall configuration help.";
     }
+
     obs_output_set_last_error(output, error);
 
     // Disconnect, this will call stop on main thread

--- a/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.h
+++ b/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.h
@@ -131,6 +131,7 @@ private:
   std::string protocol;
   std::string audio_codec;
   std::string video_codec;
+  bool connection_invalidated;
   int channel_count;
 
   // NOTE LUDO: #80 add getStats


### PR DESCRIPTION
Duplicate user errors, and in fact Janus-reported errors in general, were not resulting in correct disconnection of the WebSocket.  This resolves that issue, while preventing duplicate error reporting to the user.