### PR TITLE
[PUB-205] Installer failure

### DIFF
--- a/vendor_skins/Evercast/CI/install/win/Install EBS.wxs
+++ b/vendor_skins/Evercast/CI/install/win/Install EBS.wxs
@@ -3,7 +3,7 @@
 	xmlns:bal="http://schemas.microsoft.com/wix/BalExtension"
 	xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 	<Bundle
-	      Version="2.5.9"
+	      Version="2.6.0"
 	      UpgradeCode="01234567-89AB-CDEF-0123-456789ABCDEF"
 	      Manufacturer="Evercast"
 	      IconSourceFile=".\ebs.ico"
@@ -36,11 +36,13 @@
 				SourceFile=".\NDI 4 Runtime.exe"
 				Permanent="yes" />
 			<ExePackage
+				InstallCondition="NOT (VCRedist2015x64 = v14.25.28508)"
 				SourceFile=".\VC_redist.x64.exe"
 				InstallCommand="/q /ACTION=Install"
 				RepairCommand="/q ACTION=Repair /hideconsole"
-				Permanent="yes" />
-			<MsiPackage SourceFile=".\ebs-x64-2.5.9.msi" />
+				Permanent="yes"
+				Vital="no"/>
+			<MsiPackage SourceFile=".\ebs-x64-2.6.0.msi" />
 		</Chain>
 	</Bundle>
 </Wix>


### PR DESCRIPTION
Some versions of the VC++ redistributable are bugged, leaving bad data in the registry that causes the installer to fail.

One option is to modify the user's registry/uninstaller older redistributables, but this is excessive and could have unforeseen consequences, damaging user desktops.

Alternatively, we can continue installing even if the redistributable fails to install.  This can sometimes fail, if installation of VCRedist fails, and no suitable alternative is available.  However it is preferable to the alternatives.