### PR TITLE
[PUB-172] Improper reconnect on web client reload

### DIFF
--- a/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.cpp
+++ b/vendor_skins/Evercast/plugins/obs-outputs/WebRTCStream.cpp
@@ -618,6 +618,9 @@ void WebRTCStream::onLoggedError(int code)
     }
 
     this->connection_invalidated = true;
+    if (client) {
+	client->disconnect(false);
+    }
     crit_.Leave();
 
     // Close Peer Connection


### PR DESCRIPTION
WebSocket connection was left open under some circumstances.  It is now closed when an error occurs that should result in it closing.