### PR TITLE
[PUB-228] Remove h264

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -31,6 +31,7 @@ enum class Section : int {
 	StreamKey,
 };
 
+#define CODEC_NAME_H264 "h264"
 #define CODEC_NAME_VP9 "vp9"
 
 // NOTE LUDO: #167 Settings/Stream: only one service displayed: Evercast
@@ -142,9 +143,13 @@ void OBSBasicSettings::LoadStream1Settings()
 
 		tmpString = obs_data_get_string(settings, "codec");
 		const char *codec =
-                // NOTE LUDO: #172 codecs list of radio buttons
-		// 	strcmp("", tmpString) == 0 ? "Automatic" : tmpString;
-			strcmp("", tmpString) == 0 ? CODEC_NAME_VP9 : tmpString;
+			strcmp("", tmpString) == 0 ? CODEC_NAME_VP9 :
+			#ifdef _WIN32
+				strcmp(CODEC_NAME_H264, tmpString) == 0 ? CODEC_NAME_VP9 : tmpString
+			#else
+				tmpString
+			#endif 
+			;
 
 		tmpString = obs_data_get_string(settings, "protocol");
 		const char *protocol =

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -354,10 +354,12 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->authPw,               EDIT_CHANGED,   STREAM1_CHANGED);
   // NOTE LUDO: #172 codecs list of radio buttons
 	// HookWidget(ui->codec,                COMBO_CHANGED,  STREAM1_CHANGED);
+	#ifndef _WIN32
 	HookWidget(ui->h264RadioButton,      CHECK_CHANGED,  STREAM1_CHANGED);
+	HookWidget(ui->h264RadioButton,      CHECK_CHANGED,  PROTOCOL_CHANGED);
+	#endif
 	HookWidget(ui->vp8RadioButton,       CHECK_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->vp9RadioButton,       CHECK_CHANGED,  STREAM1_CHANGED);
-	HookWidget(ui->h264RadioButton,      CHECK_CHANGED,  PROTOCOL_CHANGED);
 	HookWidget(ui->vp8RadioButton,       CHECK_CHANGED,  PROTOCOL_CHANGED);
 	HookWidget(ui->vp9RadioButton,       CHECK_CHANGED,  VP9_CHANGED);
 	HookWidget(ui->streamProtocol,       COMBO_CHANGED,  STREAM1_CHANGED);
@@ -750,9 +752,14 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	// 		this, SLOT(SimpleRecordingEncoderChanged()));
 
   // NOTE LUDO: #172 codecs list of radio buttons
-  ui->codecButtonGroup->setId(ui->h264RadioButton, 0);
-  ui->codecButtonGroup->setId(ui->vp8RadioButton,  1);
-  ui->codecButtonGroup->setId(ui->vp9RadioButton,  2);
+  int codecIndex = 0;
+  #ifndef _WIN32
+  ui->codecButtonGroup->setId(ui->h264RadioButton, codecIndex++);
+  #else
+  ui->h264RadioButton->setVisible(false);
+  #endif
+  ui->codecButtonGroup->setId(ui->vp8RadioButton,  codecIndex++);
+  ui->codecButtonGroup->setId(ui->vp9RadioButton,  codecIndex++);
   ui->vp9WarnLabel->setVisible(false);
 
   // NOTE LUDO: #173 replace Settings/Stream service Evercast combo box by a radio button
@@ -934,17 +941,19 @@ void OBSBasicSettings::LoadEncoderTypes()
 		if (obs_get_encoder_type(type) != OBS_ENCODER_VIDEO)
 			continue;
 
+		bool is_streaming_codec = false;
+		#ifndef _WIN32 
 		const char *streaming_codecs[] = {
 			"h264",
 			//"hevc",
 		};
-		bool is_streaming_codec = false;
 		for (const char *test_codec : streaming_codecs) {
 			if (strcmp(codec, test_codec) == 0) {
 				is_streaming_codec = true;
 				break;
 			}
 		}
+		#endif
 		if ((caps & OBS_ENCODER_CAP_DEPRECATED) != 0)
 			continue;
 

--- a/plugins/rtmp-services/webrtc-evercast.c
+++ b/plugins/rtmp-services/webrtc-evercast.c
@@ -26,10 +26,19 @@ static void webrtc_evercast_update(void *data, obs_data_t *settings)
   bfree(service->codec);
   bfree(service->output);
 
+  #ifdef _WIN32
+  const char *raw_codec = obs_data_get_string(settings, "codec");
+  if (strncmp("h264", raw_codec, 4) == 0) {
+	  raw_codec = "vp9";
+  }
+  #else
+  const char *raw_codec = obs_data_get_string(settings, "codec");
+  #endif
+
   service->server = bstrdup(obs_data_get_string(settings, "server"));
   service->room = bstrdup(obs_data_get_string(settings, "room"));
   service->password = bstrdup(obs_data_get_string(settings, "password"));
-  service->codec = bstrdup(obs_data_get_string(settings, "codec"));
+  service->codec = bstrdup(raw_codec);
   service->output = bstrdup("evercast_output");
 }
 


### PR DESCRIPTION
Removed H264, set default to VP9 for existing installs with h264 defined.