### PR TITLE
JanusWebsocketManager: close messageQueue when disconnecting.

### DIFF
--- a/plugins/websocket-client/JanusWebsocketManager.cpp
+++ b/plugins/websocket-client/JanusWebsocketManager.cpp
@@ -167,6 +167,8 @@ bool JanusWebsocketManager::disconnect(const bool wait)
 			     ec.message().c_str());
 		// Don't wait for connection close
 		client.stop();
+		// Stop the message queue
+                messageQueue.close();
 		// Remove handlers
 		client.set_open_handler([](...) {});
 		client.set_close_handler([](...) {});


### PR DESCRIPTION
If `messageQueue` not closed we can end-up on waiting for messages [here](https://github.com/evercast/evercast-broadcaster-software/blob/ebs-2.6/plugins/websocket-client/JanusWebsocketManager.cpp#L216) that will never come and blocking the main-thread.