### PR TITLE
[PUB-225] Settings window now won't exceed the size of the screen on Windows

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -292,9 +292,12 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->setupUi(this);
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+#ifdef _WIN32
 	QScreen *screen = App()->GetMainWindow()->windowHandle()->screen();
 	const int screenHeight = screen->availableGeometry().height();
 	setMaximumHeight(screenHeight * 0.9); // QT itself is not very reliable on the subject of "available size"
+#endif
 
 	main->EnableOutputs(false);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -34,6 +34,7 @@
 #include <QScreen>
 #include <QStandardItemModel>
 #include <QSpacerItem>
+#include <QWindow>
 
 #include "audio-encoders.hpp"
 #include "hotkey-edit.hpp"
@@ -291,6 +292,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->setupUi(this);
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+	QScreen *screen = App()->GetMainWindow()->windowHandle()->screen();
+	const int screenHeight = screen->availableGeometry().height();
+	setMaximumHeight(screenHeight * 0.9); // QT itself is not very reliable on the subject of "available size"
 
 	main->EnableOutputs(false);
 


### PR DESCRIPTION
QT occasionally likes to include the taskbar in its "available size" metric.  Also popular is picking the wrong display.  This fix should resolve the issue.